### PR TITLE
Add baseline system test setup with chrome headless

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ gem 'mini_magick', '~> 4.9'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-  gem 'rspec-rails'
   gem 'factory_bot_rails'
   gem 'faker'
 end
@@ -28,6 +27,13 @@ group :development do
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'irb', require: false
+end
+
+group :test do
+  gem 'rspec-rails'
+  gem 'capybara'
+  gem 'webdrivers'
+  gem 'capybara-screenshot'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,12 +56,26 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     bcrypt (3.1.13)
     bindex (0.8.1)
     bootsnap (1.4.5)
       msgpack (~> 1.0)
     builder (3.2.3)
     byebug (11.0.1)
+    capybara (3.29.0)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.5)
+      xpath (~> 3.2)
+    capybara-screenshot (1.0.24)
+      capybara (>= 1.0, < 4)
+      launchy
+    childprocess (3.0.0)
     concurrent-ruby (1.1.5)
     crass (1.0.5)
     devise (4.7.1)
@@ -85,6 +99,8 @@ GEM
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
     irb (1.0.0)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -107,6 +123,7 @@ GEM
     nokogiri (1.10.5)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
+    public_suffix (4.0.1)
     puma (4.3.0)
       nio4r (~> 2.0)
     rack (2.0.7)
@@ -144,6 +161,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    regexp_parser (1.6.0)
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -165,6 +183,7 @@ GEM
       rspec-support (~> 3.9.0)
     rspec-support (3.9.0)
     ruby_dep (1.5.0)
+    rubyzip (2.2.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.2.1)
@@ -175,6 +194,9 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -202,6 +224,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webdrivers (4.1.3)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     webpacker (4.2.0)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
@@ -209,6 +235,8 @@ GEM
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zeitwerk (2.2.1)
 
 PLATFORMS
@@ -217,6 +245,8 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
+  capybara
+  capybara-screenshot
   devise
   factory_bot_rails
   faker
@@ -233,6 +263,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   web-console (>= 3.3.0)
+  webdrivers
   webpacker (~> 4.0)
 
 RUBY VERSION

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,20 @@
 
   <body>
     <%= render 'layouts/nav' %>
+
+    <% if flash[:alert] %>
+      <div role="alert">
+        <div class="bg-red-500 text-white font-bold rounded-t px-4 py-2">
+          Uh oh!
+        </div>
+        <% flash.each do |type, msg| %>
+          <div class="border border-t-0 border-red-400 rounded-b bg-red-100 px-4 py-3 text-red-700">
+            <p><%= msg %></p>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+
     <%= yield %>
   </body>
 </html>

--- a/bin/setup
+++ b/bin/setup
@@ -17,6 +17,14 @@ FileUtils.chdir APP_ROOT do
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
 
+  if RUBY_PLATFORM =~ /darwin/
+    unless system('brew cask ls --versions chromedriver')
+    system('brew cask install chromedriver')
+    end
+  else
+    puts 'You will need to install Chromedriver before using the automated test suite.'
+  end
+
   # Install JavaScript dependencies
   # system('bin/yarn')
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -46,7 +46,11 @@ RSpec.configure do |config|
   end
 
   config.before(:each, type: :system, js: true) do
-    driven_by(:selenium_chrome_headless)
+    if ENV['BROWSER']
+      driven_by(:selenium_chrome)
+    else
+      driven_by(:selenium_chrome_headless)
+    end
   end
 
   # RSpec Rails can automatically mix in different behaviours to your tests

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -41,6 +41,14 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = true
 
+  config.before(:each, type: :system) do
+    driven_by(:rack_test)
+  end
+
+  config.before(:each, type: :system, js: true) do
+    driven_by(:selenium_chrome_headless)
+  end
+
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.

--- a/spec/support/chromedriver.rb
+++ b/spec/support/chromedriver.rb
@@ -1,0 +1,7 @@
+require 'selenium/webdriver'
+require 'capybara-screenshot/rspec'
+Capybara.javascript_driver = :selenium_chrome_headless
+
+Capybara::Screenshot.register_driver(:selenium_chrome_headless) do |driver, path|
+  driver.browser.save_screenshot(path)
+end

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -1,4 +1,5 @@
 RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::ControllerHelpers, type: :view
+  config.include Devise::Test::IntegrationHelpers, type: :system
 end

--- a/spec/system/login_spec.rb
+++ b/spec/system/login_spec.rb
@@ -3,13 +3,28 @@ require "rails_helper"
 RSpec.describe "Login", type: :system, js: true do
   let(:user) { create(:user) }
 
-  it "enables me to create widgets" do
-    visit new_user_session_path
+  context "using the correct credentials" do
+    it "logs me in" do
+      visit new_user_session_path
+      
+      expect(page).to have_text("Please Sign In")
+      fill_in "Email", with: user.email
+      fill_in "Password", with: user.password
+      click_on("Log in")
+  
+      expect(page).to have_text("Logout")
+    end
+  end
 
-    fill_in "Email", with: user.email
-    fill_in "Password", with: user.password
-    click_link_or_button "Login"
-
-    expect(page).to have_text("Recipes")
+  context "using incorrect credentials" do
+    it "displays error messages" do
+      visit new_user_session_path
+  
+      fill_in "Email", with: "bogus@example.com"
+      fill_in "Password", with: "bogus"
+      click_on("Log in")
+  
+      expect(page).to have_text("Invalid Email or password.")
+    end
   end
 end

--- a/spec/system/login_spec.rb
+++ b/spec/system/login_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe "Login", type: :system, js: true do
+  let(:user) { create(:user) }
+
+  it "enables me to create widgets" do
+    visit new_user_session_path
+
+    fill_in "Email", with: user.email
+    fill_in "Password", with: user.password
+    click_link_or_button "Login"
+
+    expect(page).to have_text("Recipes")
+  end
+end


### PR DESCRIPTION
This sets up system tests using chromedriver in headless mode for system tests tagged with `js: true`.